### PR TITLE
feature:add asan library for detect memory leak

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,38 @@ else()
 	include_directories(${JSON-C_INCLUDE_DIR})
 endif(THIRDPARTY_STATIC_BUILD)
 
+macro(check_asan _RESULT)
+    include(CheckCSourceRuns)
+    set(CMAKE_REQUIRED_FLAGS "-fsanitize=address")
+    check_c_source_runs(
+            [====[
+int main()
+{
+  return 0;
+}
+]====]
+            ${_RESULT}
+    )
+    unset(CMAKE_REQUIRED_FLAGS)
+endmacro()
+
+# Enable address sanitizer
+option(ENABLE_SANITIZER "Enable sanitizer(Debug+Gcc/Clang/AppleClang)" ON)
+if(ENABLE_SANITIZER AND NOT MSVC)
+    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+        check_asan(HAS_ASAN)
+        if(HAS_ASAN)
+		message(WARNING "add sanitizer")
+		set(asan_c_flags "-fsanitize=address -fsanitize=leak")
+		set(asan_c_libs "asan")
+        else()
+            message(WARNING "sanitizer is no supported with current tool-chains")
+        endif()
+    else()
+        message(WARNING "Sanitizer supported only for debug type")
+    endif()
+endif()
+
 set(src_xfrpc
 	main.c
   	client.c
@@ -60,14 +92,14 @@ set(test_libs
 	event
 	)
 
-ADD_DEFINITIONS(-Wall -g  --std=gnu99)
+ADD_DEFINITIONS(-Wall -g  --std=gnu99 ${asan_c_flags})
 
 if (STATIC_BUILD STREQUAL "ON")
   add_link_options(-static)
 endif (STATIC_BUILD)
 
 add_executable(xfrpc ${src_xfrpc})
-target_link_libraries(xfrpc ${libs} ${static_libs})
+target_link_libraries(xfrpc ${libs} ${static_libs} ${asan_c_libs})
 
 install(TARGETS xfrpc
         RUNTIME DESTINATION bin

--- a/README.md
+++ b/README.md
@@ -176,6 +176,16 @@ xfrpc is included in the OpenWrt community since version 1.04.515, which allows 
 
 To include xfrpc in your OpenWrt firmware image, you can use the make menuconfig command to open the configuration menu. In the menu, navigate to "Network" and select "Web Servers/Proxies" and then select xfrpc. This will include xfrpc in the firmware image that will be built.
 
+### Build xfrpc with asan(For detect memory leak)
+
+When encountering a segment fault, please use the following command to compile xfrpc:
+
+```shell
+cmake -DCMAKE_BUILD_TYPE=Debug ..
+```
+
+Now your xfrpc can detect memory leak.We will add it in ci flow in future.
+
 ## Quick start for use
 
 **before using xfrpc, you should get frps server: [frps](https://github.com/fatedier/frp/releases)**


### PR DESCRIPTION
When encountering a segment fault,Address-Sanitizier can auto detect memory leak.
The debug mode should be added in the ci workflow to avoid memory errors.