### PR TITLE
Fix: Implement configuration memory cleanup at shutdown

### DIFF
--- a/config.c
+++ b/config.c
@@ -835,3 +835,55 @@ struct proxy_service *get_all_proxy_services()
 {
 	return all_ps;
 }
+
+/**
+ * @brief Frees memory used by a proxy_service structure
+ *
+ * Deallocates memory for dynamically allocated strings within the proxy_service
+ * structure and the structure itself.
+ *
+ * @param ps Pointer to the proxy_service structure to free
+ */
+void free_proxy_service(struct proxy_service *ps)
+{
+	if (!ps) {
+		return;
+	}
+
+	SAFE_FREE(ps->proxy_name);
+	SAFE_FREE(ps->ftp_cfg_proxy_name);
+	SAFE_FREE(ps->proxy_type);
+	SAFE_FREE(ps->local_ip);
+	SAFE_FREE(ps->custom_domains);
+	SAFE_FREE(ps->subdomain);
+	SAFE_FREE(ps->locations);
+	SAFE_FREE(ps->host_header_rewrite);
+	SAFE_FREE(ps->http_user);
+	SAFE_FREE(ps->http_pwd);
+	SAFE_FREE(ps->group);
+	SAFE_FREE(ps->group_key);
+	SAFE_FREE(ps->plugin);
+	SAFE_FREE(ps->plugin_user);
+	SAFE_FREE(ps->plugin_pwd);
+	SAFE_FREE(ps->s_root_dir);
+	SAFE_FREE(ps->bind_addr);
+	SAFE_FREE(ps);
+}
+
+/**
+ * @brief Frees all proxy_service structures from the all_ps hash table.
+ *
+ * Iterates through the all_ps hash table, removes each element,
+ * and frees the associated proxy_service structure using free_proxy_service.
+ * Finally, sets all_ps to NULL.
+ */
+void free_all_proxy_services(void)
+{
+	struct proxy_service *current_ps, *tmp;
+
+	HASH_ITER(hh, all_ps, current_ps, tmp) {
+		HASH_DEL(all_ps, current_ps);  /* delete it (all_ps advances to next) */
+		free_proxy_service(current_ps); /* free it */
+	}
+	all_ps = NULL; /* Ensure the hash table head is NULL after clearing */
+}

--- a/config.h
+++ b/config.h
@@ -55,6 +55,8 @@ void load_config(const char *confile);
 /* Proxy service management functions */
 struct proxy_service *get_proxy_service(const char *proxy_name);
 struct proxy_service *get_all_proxy_services(void);
+void free_proxy_service(struct proxy_service *ps);
+void free_all_proxy_services(void);
 int validate_proxy(struct proxy_service *ps);
 
 /* FTP specific functions */

--- a/xfrpc.c
+++ b/xfrpc.c
@@ -84,4 +84,6 @@ void xfrpc_loop(void)
 	init_main_control();
 	run_control();
 	close_main_control();
+	free_all_proxy_services(); /* Clean up all proxy service configurations */
+	free_common_config();      /* Clean up common configuration */
 }


### PR DESCRIPTION
This commit addresses potential memory leaks by ensuring that dynamically allocated configuration data is freed when the xfrpc client terminates.

The following changes were made:

1.  Added `free_proxy_service(struct proxy_service *ps)` function in `config.c` to deallocate a single proxy service structure and all its dynamically allocated string members.
2.  Added `free_all_proxy_services()` function in `config.c` to iterate through the global `all_ps` hash table, removing each service and calling `free_proxy_service()` on it.
3.  Modified `xfrpc_loop()` in `xfrpc.c` to call `free_all_proxy_services()` and `free_common_config()` after `close_main_control()` to ensure all configuration memory is released before the program exits.

A review of `client.c` for `proxy_client` management (`clear_all_proxy_client` and `free_proxy_client`) was also conducted, and the existing memory management for client structures appears to be correct.