### PR TITLE
fix: update broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ QQ群 ： [331230369](https://jq.qq.com/?_wv=1027&k=47QGEhL)
 
 ## Please support us and star our project
 
-[![Star History Chart](https://api.star-history.com/svg?repos=liudf0716/xfrpc&type=Date)](https://star-history.com/#liudf0716/xfrpc&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=liudf0716/xfrpc&type=Date)](https://star-history.dera.page/#liudf0716/xfrpc&Date)
 
 ## 打赏
 


### PR DESCRIPTION
The star history chart in the README is currently broken because GitHub stargazer API restrictions prevent it from rendering. This change updates the chart image and link to a working alternative that requires no API token, so the chart displays correctly again.